### PR TITLE
Add support for effects and unowned items

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,8 @@ Each field config *must* define the following:
  - `dataMode`: this defines what data is shown in the Autocompleter interface. This can take the following values:
    - `DATA_MODE.ENTITY_DATA`: The data of the sheet's entity
    - `DATA_MODE.ROLL_DATA`: The roll data of the sheet's entity
-   - `DATA_MODE.OWNING_ACTOR_DATA`: The data of the sheet's entity's owning actor
-   - `DATA_MODE.OWNING_ACTOR_ROLL_DATA`: The roll data of the sheet's entity's owning actor
+   - `DATA_MODE.OWNING_ACTOR_DATA`: The data of the sheet's entity's owning actor, falling back to the merged data of dummy actors of all types if the entity is not owned
+   - `DATA_MODE.OWNING_ACTOR_ROLL_DATA`: The roll data of the sheet's entity's owning actor, falling back to the merged roll data of dummy actors of all types if the entity is not owned
    - `DATA_MODE.CUSTOM`: Custom data as defined by the `customDataGetter`
  - `customDataGetter`: when `dataMode` is `CUSTOM`, the function provided here will be used to get the data to be shown in the Autocompleter interface.
     When `dataMode` is `CUSTOM`, this field is *required*.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ Pressing "Enter", or clicking on the insert button to the right of the path text
 
 Module and system authors can enable or disable the option to press the "@" hotkey, or the floating "@" button on a per-field basis.
 
-## Limitations
-
-Currently, AIP will not work for items that are not owned by an actor. It should be possible to resolve this limitation once core 0.8 is released, but for now you'll only be able to use it when the item is on an actor.
-
 ## Compatibility
 
 This module currently offers built in support for the dnd5e system, though I am more than willing to accept pull requests to support other systems.

--- a/package-config.mjs
+++ b/package-config.mjs
@@ -23,8 +23,8 @@ const DATA_MODE = {
 const DATA_GETTERS = {
     [DATA_MODE.ENTITY_DATA]: (sheet) => sheet.object?.data,
     [DATA_MODE.ROLL_DATA]: (sheet) => sheet.object?.getRollData(),
-    [DATA_MODE.OWNING_ACTOR_DATA]: (sheet) => _getSheetEntityParentActor(sheet)?.data ?? null,
-    [DATA_MODE.OWNING_ACTOR_ROLL_DATA]: (sheet) => _getSheetEntityParentActor(sheet)?.getRollData() ?? null,
+    [DATA_MODE.OWNING_ACTOR_DATA]: (sheet) => _getSheetEntityParentActor(sheet)?.data ?? _getFallbackActorData(),
+    [DATA_MODE.OWNING_ACTOR_ROLL_DATA]: (sheet) => _getSheetEntityParentActor(sheet)?.getRollData() ?? _getFallbackActorRollData(),
     [DATA_MODE.CUSTOM]: (sheet, customDataGetter) => customDataGetter(sheet),
 }
 
@@ -35,10 +35,58 @@ const DATA_GETTERS = {
  * @returns {Actor|null}
  * @private
  */
-function _getSheetEntityParentActor(sheet) {
+ function _getSheetEntityParentActor(sheet) {
     const parent = sheet.object?.actor ?? sheet.object?.parent;
     return (parent && parent instanceof Actor) ? parent : null;
 }
+
+/**
+ * The cached merged actor data to use as fallback for unowned documents
+ * @type {object}
+ * @private
+ */
+let _fallbackActorData;
+
+/**
+ * Gets an object containing the merged data of all actor types.
+ * @returns {object}
+ * @private
+ */
+function _getFallbackActorData() {
+    if(!_fallbackActorData) {
+        const cls = getDocumentClass("Actor");
+        _fallbackActorData = {};
+        for(const type of game.system.template.Actor.types) {
+            const actorData = new cls({ type, name: "dummy" }).data;
+            foundry.utils.mergeObject(_fallbackActorData, actorData)
+        }
+    }
+    return _fallbackActorData;
+}
+
+/**
+ * The cached merged actor roll data to use as fallback for unowned documents
+ * @type {object}
+ * @private
+ */
+ let _fallbackActorRollData;
+
+ /**
+  * Gets an object containing the merged roll data of all actor types.
+  * @returns {object}
+  * @private
+  */
+ function _getFallbackActorRollData() {
+     if(!_fallbackActorRollData) {
+         const cls = getDocumentClass("Actor");
+         _fallbackActorData = {};
+         for(const type of game.system.template.Actor.types) {
+             const actorRollData = new cls({ type, name: "dummy" }).getRollData();
+             foundry.utils.mergeObject(_fallbackActorRollData, actorRollData)
+         }
+     }
+     return _fallbackActorRollData;
+ }
 
 /**
  * @typedef {Object} AIPPackageConfig


### PR DESCRIPTION
In order to get completion of actor properties  for effects unowned items,
dummy actors of all types are created and their data is merged together
to be used as source for the completion.

Closes #2