### PR TITLE
fix(deps): add fs-extra required for package-link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "eslint": "8.57.0",
                 "eslint-config-prettier": "9.1.0",
                 "eslint-plugin-prettier": "4.2.1",
+                "fs-extra": "^11.2.0",
                 "husky": "9.1.5",
                 "lint-staged": "15.2.9",
                 "npm-run-all2": "6.2.2",
@@ -3576,6 +3577,21 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4684,6 +4700,19 @@
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
         },
         "node_modules/jsonparse": {
             "version": "1.3.1",
@@ -6956,6 +6985,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "4.2.1",
+        "fs-extra": "^11.2.0",
         "husky": "9.1.5",
         "lint-staged": "15.2.9",
         "npm-run-all2": "6.2.2",


### PR DESCRIPTION
Fixes a failure with `npm run package-link` due to missing `fs-extra` dependency.

## Issue

`npm run link-package` command requires `fs-extra`, but this is not defined in `package.json` dependencies:

https://github.com/ghost-fvtt/FVTT-Autocomplete-Inline-Properties/blob/3c627766a0ef443fb03a89f49498fab6c8dd7e8a/tools/link-package.mjs#L5

This results in a failure when running `npm run link-package`

```
➜ npm run link-package

> autocomplete-inline-properties@2.9.1 link-package
> node ./tools/link-package.mjs

node:internal/modules/esm/resolve:841
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'fs-extra' imported from /Users/lazulit3/projects/ttrpg/foundry/modules/FVTT-Autocomplete-Inline-Properties/tools/link-package.mjs
    at packageResolve (node:internal/modules/esm/resolve:841:9)
    at moduleResolve (node:internal/modules/esm/resolve:914:18)
    at defaultResolve (node:internal/modules/esm/resolve:1119:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:541:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:510:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v22.3.0
```

### Reproduce

On `main` branch:

```sh
# Clean up to remove existing node_modules dependencies
rm -rf node_modules

# Install dependencies
npm install

# Configure foundryconfig.json with your dataPath w/ preferred editor
zed foundryconfig.json

# Build the package
npm run build

# Try linking the package
npm run link-package
```

## Testing

I repeated the steps above and verified that this resolves errors affecting `npm run link-package` and `npm run clean` (when cleaning up the link).